### PR TITLE
docs: add sonic_boom ability documentation

### DIFF
--- a/docs/data_types/abilities/sonic_boom.mdx
+++ b/docs/data_types/abilities/sonic_boom.mdx
@@ -1,0 +1,54 @@
+# Sonic Boom Ability
+
+## Description
+
+The `sonic_boom` ability allows the player to **emit a sonic boom** that damages all nearby living entities in a configurable range, by using and holding the item.
+
+### Features
+
+- Requires a minimum hold time before activation.
+- Damages all living entities within a configurable spherical range centered on the player.
+- Spawns `SONIC_BOOM` particles on each affected entity.
+- Plays a configurable sound event on activation (default is `warden.sonic_boom`).
+- Applies a cooldown after use.
+- Only executes on the server side (requires `ServerLevel`).
+- Uses a `SPYGLASS` animation while holding the item.
+- Supports merging and initialization of all configurable parameters.
+
+### Context Fields (SonicBoomContext)
+
+| Field      | Type                        | Description                                                        | Default Value              |
+|------------|-----------------------------|--------------------------------------------------------------------|----------------------------|
+| on_boom    | `SoundEvent`                | Sound played when the sonic boom is released                       | `warden_sonic_boom`        |
+| min_hold   | `DoubleOperationResolvable` | Minimum ticks the item must be held before activation              | `15`                       |
+| damage     | `DoubleOperationResolvable` | Amount of damage dealt to each entity in range                     | `10`                       |
+| cooldown   | `DoubleOperationResolvable` | Cooldown duration in ticks after use                               | `20`                       |
+| max_range  | `DoubleOperationResolvable` | Radius in blocks around the player that entities are affected      | `5`                        |
+
+### Example
+
+```json
+{
+    "ability_context": [
+        {
+            "id": "addon:test",
+            "type": "miapi:sonic_boom",
+            "priority": 0,
+            "data": {
+                "damage": "[material.tier]*5",
+                "cooldown": 40,
+                "max_range": 8,
+                "min_hold": 20
+            }
+        }
+    ]
+}
+```
+
+### Usage
+
+- Player holds the item (right-click and hold).
+- On release after the minimum hold time, the ability deals damage to all living entities within `max_range` blocks of the player.
+- The `on_boom` sound is played at the player's position.
+- `SONIC_BOOM` particles are spawned at each affected entity's position.
+- A cooldown is applied after a successful activation.


### PR DESCRIPTION
Adds missing documentation for the `sonic_boom` ability (`miapi:sonic_boom`).

## Changes

- New file: `docs/data_types/abilities/sonic_boom.mdx`

## What is documented

All 5 fields of `SonicBoomContext` are covered with types, descriptions, and defaults:

| Field      | Type                        | Default             |
|------------|-----------------------------|---------------------|
| `on_boom`  | `SoundEvent`                | `warden_sonic_boom` |
| `min_hold` | `DoubleOperationResolvable` | `15`                |
| `damage`   | `DoubleOperationResolvable` | `10`                |
| `cooldown` | `DoubleOperationResolvable` | `20`                |
| `max_range`| `DoubleOperationResolvable` | `5`                 |

Also documents the `SPYGLASS` use animation, SONIC_BOOM particle effect, area-of-effect behaviour, and includes a JSON example.