### PR TITLE
docs: add missing auto_smelt and global_loot_modularisation loot function docs

### DIFF
--- a/docs/data_types/loot_functions/auto_smelt.mdx
+++ b/docs/data_types/loot_functions/auto_smelt.mdx
@@ -1,0 +1,11 @@
+# Auto Smelt Loot Function
+
+## Description
+
+The `AutoSmeltFunction` is a loot function that automatically smelts item drops when the tool used has the `auto_smelt` module property enabled. When applied, it checks whether the tool that produced the drop has the auto smelt property set, then looks up a matching smelting recipe for the dropped item and replaces it with the smelted result. If no smelting recipe exists for the drop, the original item is returned unchanged.
+
+Its full ID is ```"miapi:auto_smelt"```
+
+## Data
+
+This loot function has no configurable parameters.

--- a/docs/data_types/loot_functions/global_loot_modularisation.mdx
+++ b/docs/data_types/loot_functions/global_loot_modularisation.mdx
@@ -1,0 +1,11 @@
+# Global Loot Modularisation Loot Function
+
+## Description
+
+The `GlobalLootModularisationFunction` is a loot function that applies all globally registered loot adjustment functions to an item when it is generated as loot. Adjustments are registered centrally via `LootHelper` and run sequentially over the item stack. This allows mods and datapacks to inject universal loot behaviour — such as randomising materials or applying enchantments — without modifying individual loot tables.
+
+Its full ID is ```"miapi:global_loot_adjuster"```
+
+## Data
+
+This loot function has no configurable parameters.


### PR DESCRIPTION
Adds documentation for miapi:auto_smelt (smelts drops, no parameters) and miapi:global_loot_adjuster (applies loot adjustments to modular items, no parameters) — both were implemented but completely undocumented.