### PR TITLE
riptide ability wiki

### DIFF
--- a/common/src/main/java/smartin/miapi/modules/abilities/RiptideAbility.wiki.md
+++ b/common/src/main/java/smartin/miapi/modules/abilities/RiptideAbility.wiki.md
@@ -1,10 +1,38 @@
 @header Riptide Ability  
 @path /data_types/abilities/riptide
 
+The **Riptide Ability** propels the player through the air when used near water or rain, replicating vanilla riptide behavior on modular items.
+
+---
+
+### Behavior
+
+- Activates on right-click and hold; releases after the minimum hold time.
+- Requires the player to be touching water, rain, or a configured custom fluid.
+- Launches the player with configurable strength, evaluated against the Riptide enchantment level.
+- Plays a spin animation for a configurable duration after launch.
+- Applies a cooldown after each use.
+- Only executes on the server side.
+
+---
+
+### Fields
+
+| Field                | Type                                        | Description                                                                             |
+|----------------------|---------------------------------------------|-----------------------------------------------------------------------------------------|
+| `cooldown`           | `DoubleOperationResolvable` *(default: 20)* | Ticks before the ability can be used again.                                             |
+| `min_use`            | `DoubleOperationResolvable` *(default: 10)* | Minimum ticks the item must be held before it activates.                                |
+| `spin_duration_base` | `DoubleOperationResolvable` *(default: 20)* | Base spin animation duration in ticks. Each Riptide enchantment level adds to this.     |
+| `riptide_strength`   | `DoubleOperationResolvable` *(optional)*    | Launch strength. Evaluated against the vanilla Riptide enchantment strength; defaults to that value (0 without an enchant). |
+| `require_fluid`      | `boolean` *(default: true)*                 | If true, the player must be touching a fluid to activate.                               |
+| `custom_fluid`       | `string` *(optional)*                       | Fluid tag ID to require instead of water. Omitting this also allows activation in rain. |
+| `custom_sound`       | `SoundEvent` *(optional)*                   | Sound played on launch. Defaults to the vanilla riptide sound.                          |
+
+---
 
 ### Example
 
-```json5
+```json
 {
     "ability_context": [
         {
@@ -12,28 +40,23 @@
             "type": "miapi:riptide",
             "data": {
                 "cooldown": 20,
-                //time in ticks before this can be used again.
-                //the item will get vanillas cooldown system applied
                 "min_use": 10,
-                //windup min time in ticks
-                //defaults to 20 if not set
                 "spin_duration_base": 0,
-                //spin time, enchantments add to this (riptide)
-                //defaults to 0
                 "riptide_strength": 3,
-                //strength, each level fo enchantment gives one. 0 makes u not move
-                //default 0
                 "require_fluid": true,
-                //if the player touching a fluid is required, 
-                //default true
                 "custom_fluid": "minecraft:lava",
-                //allows for custom fluid tag
-                //if not set defaults to water (minecraft:water and not setting is different, not setting it will also allow for rain)
-                //default unset
-                "custom_sound": "minecraft:item.armor.equip_diamond",
-                //allows for custom sound, by default players riptide sounds
+                "custom_sound": "minecraft:item.armor.equip_diamond"
             }
         }
     ]
 }
 ```
+
+This configuration:
+- Sets a 20-tick cooldown after each use,
+- Requires a 10-tick hold before launching,
+- Disables the spin animation,
+- Sets a fixed launch strength of 3,
+- Requires the player to be touching a fluid,
+- Requires lava specifically instead of water or rain,
+- Plays the diamond armor equip sound on launch.


### PR DESCRIPTION
the riptide wiki stub was basically empty and what was there had wrong defaults baked into the json5 comments:

- min_use said "defaults to 20" — actual default is 10 (L205 (https://github.com/Truly-Modular/Modular-Item-API/blob/release/1.21-mojmaps/common/src/main/java/smartin/miapi/modules/abilities/RiptideAbility.java#L205))
- spin_duration_base said "defaults to 0" — actual default is 20 (L208 (https://github.com/Truly-Modular/Modular-Item-API/blob/release/1.21-mojmaps/common/src/main/java/smartin/miapi/modules/abilities/RiptideAbility.java#L208))
- ~~`riptide_strength` said "default 0" — actual default is 20 (L211 (https://github.com/Truly-Modular/Modular-Item-API/blob/release/1.21-mojmaps/common/src/main/java/smartin/miapi/modules/abilities/RiptideAbility.java#L211))~~

^ Adjusted, see reply

fleshed out the full page: added a description, behavior bullets, and a fields table with proper types and defaults. switched the example from json5 to plain json with a breakdown below it, to match how the other ability pages are written.

If I am wrong about the defaults, please let me know.
